### PR TITLE
Custom props for goals

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,6 @@ trackPageview({
 
 The second parameter is an object with [some options](https://plausible-tracker.netlify.app/globals.html#eventoptions) similar to the ones provided by the [official Plausible script](https://docs.plausible.io/custom-event-goals). 
 
-The only supported option at the moment is `callback` – a function that is called once the event is logged successfully.
-
 ```ts
 import Plausible from 'plausible-tracker'
 
@@ -177,6 +175,12 @@ const { trackEvent } = Plausible()
 trackEvent('signup')
 ```
 
+Custom props can be provided using the third parameter:
+```ts
+// Tracks the 'Download' goal and provides a 'method' property.
+trackEvent('signup', {}, { props: { method: 'HTTP' } })
+```
+
 As with [`trackPageview`](#tracking-page-views), you may also provide override values and a callback as the second and third parameters respectively:
 
 ```ts
@@ -186,11 +190,16 @@ const { trackEvent } = Plausible({
   trackLocalhost: false,
 })
 
-// Tracks the 'signup' goal with a different referrer and a callback
+// Tracks the 'signup' goal with a different referrer, a callback and props
 trackEvent(
   'signup',
   { trackLocalhost: true },
-  { callback: () => console.log('done') }
+  {
+    callback: () => console.log('done'),
+    props: {
+      variation: 'button A'
+    }
+  }
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -175,13 +175,13 @@ const { trackEvent } = Plausible()
 trackEvent('signup')
 ```
 
-Custom props can be provided using the third parameter:
+Custom props can be provided using the second parameter:
 ```ts
 // Tracks the 'Download' goal and provides a 'method' property.
-trackEvent('signup', {}, { props: { method: 'HTTP' } })
+trackEvent('signup', { props: { method: 'HTTP' } })
 ```
 
-As with [`trackPageview`](#tracking-page-views), you may also provide override values and a callback as the second and third parameters respectively:
+As with [`trackPageview`](#tracking-page-views), you may also provide override values but now through the third parameter:
 
 ```ts
 import Plausible from 'plausible-tracker'
@@ -190,16 +190,16 @@ const { trackEvent } = Plausible({
   trackLocalhost: false,
 })
 
-// Tracks the 'signup' goal with a different referrer, a callback and props
+// Tracks the 'signup' goal with a callback, props and a different referrer.
 trackEvent(
   'signup',
-  { trackLocalhost: true },
   {
     callback: () => console.log('done'),
     props: {
       variation: 'button A'
     }
-  }
+  },
+  { trackLocalhost: true }
 );
 ```
 

--- a/src/lib/request.spec.ts
+++ b/src/lib/request.spec.ts
@@ -121,4 +121,21 @@ describe('sendEvent', () => {
     xhrMockClass.ready(4);
     expect(callback).toHaveBeenCalled();
   });
+  test('sends props', () => {
+    expect(xmr).not.toHaveBeenCalled();
+    const props = { variation1: 'A', variation2: 'B' };
+    sendEvent('myEvent', defaultData, { props });
+
+    const payload = {
+      n: 'myEvent',
+      u: defaultData.url,
+      d: defaultData.domain,
+      r: defaultData.referrer,
+      w: defaultData.deviceWidth,
+      h: 0,
+      p: JSON.stringify(props)
+    };
+
+    expect(xhrMockClass.send).toHaveBeenCalledWith(JSON.stringify(payload));
+  });
 });

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -10,10 +10,19 @@ type EventPayload = {
   readonly r: Document['referrer'] | null;
   readonly w: Window['innerWidth'];
   readonly h: 1 | 0;
+  readonly p?: string;
 };
 
+// eslint-disable-next-line functional/no-mixed-type
 export type EventOptions = {
+  /**
+   * Callback called when the event is successfully sent.
+   */
   readonly callback?: () => void;
+  /**
+   * Properties to be bound to the event.
+   */
+  readonly props?: { readonly [propName: string]: string }
 };
 
 /**
@@ -46,6 +55,7 @@ export function sendEvent(
     r: data.referrer,
     w: data.deviceWidth,
     h: data.hashMode ? 1 : 0,
+    p: options && options.props ? JSON.stringify(options.props) : undefined
   };
 
   const req = new XMLHttpRequest();

--- a/src/lib/tracker.spec.ts
+++ b/src/lib/tracker.spec.ts
@@ -32,6 +32,10 @@ describe('tracker', () => {
 
   const getEventOptions: () => Required<requestModule.EventOptions> = () => ({
     callback: jest.fn(),
+    props: {
+      variation1: 'A',
+      variation2: 'B'
+    }
   });
 
   test('inits with default config', () => {

--- a/src/lib/tracker.spec.ts
+++ b/src/lib/tracker.spec.ts
@@ -73,7 +73,7 @@ describe('tracker', () => {
       const { trackEvent } = Plausible();
       expect(requestSpy).not.toHaveBeenCalled();
       const config: PlausibleOptions = getCustomData();
-      trackEvent('myEvent', config);
+      trackEvent('myEvent', undefined, config);
       expect(requestSpy).toHaveBeenCalled();
       expect(requestSpy).toHaveBeenCalledWith('myEvent', config, undefined);
     });
@@ -81,7 +81,7 @@ describe('tracker', () => {
       const { trackEvent } = Plausible();
       expect(requestSpy).not.toHaveBeenCalled();
       const options: requestModule.EventOptions = getEventOptions();
-      trackEvent('myEvent', {}, options);
+      trackEvent('myEvent', options);
       expect(requestSpy).toHaveBeenCalled();
       expect(requestSpy).toHaveBeenCalledWith(
         'myEvent',

--- a/src/lib/tracker.ts
+++ b/src/lib/tracker.ts
@@ -64,11 +64,14 @@ export type PlausibleOptions = PlausibleInitOptions & PlausibleEventData;
  *
  * // Tracks the 'signup' goal
  * trackEvent('signup')
+ * 
+ * // Tracks the 'Download' goal passing a 'method' property.
+ * trackEvent('Download', {}, { props: { method: 'HTTP' } })
  * ```
  *
  * @param eventName - Name of the event to track
  * @param eventData - Optional event data to send. Defaults to the current page's data merged with the default options provided earlier.
- * @param options - Event options. The only supported option at the moment is `callback` – a function that is called once the event is logged successfully.
+ * @param options - Event options.
  */
 type TrackEvent = (
   eventName: string,
@@ -90,7 +93,7 @@ type TrackEvent = (
  * ```
  *
  * @param eventData - Optional event data to send. Defaults to the current page's data merged with the default options provided earlier.
- * @param options - Event options. The only supported option at the moment is `callback` – a function that is called once the event is logged successfully.
+ * @param options - Event options.
  */
 type TrackPageview = (
   eventData?: PlausibleOptions,

--- a/src/lib/tracker.ts
+++ b/src/lib/tracker.ts
@@ -66,17 +66,17 @@ export type PlausibleOptions = PlausibleInitOptions & PlausibleEventData;
  * trackEvent('signup')
  * 
  * // Tracks the 'Download' goal passing a 'method' property.
- * trackEvent('Download', {}, { props: { method: 'HTTP' } })
+ * trackEvent('Download', { props: { method: 'HTTP' } })
  * ```
  *
  * @param eventName - Name of the event to track
- * @param eventData - Optional event data to send. Defaults to the current page's data merged with the default options provided earlier.
  * @param options - Event options.
+ * @param eventData - Optional event data to send. Defaults to the current page's data merged with the default options provided earlier.
  */
 type TrackEvent = (
   eventName: string,
-  eventData?: PlausibleOptions,
-  options?: EventOptions
+  options?: EventOptions,
+  eventData?: PlausibleOptions
 ) => void;
 
 /**
@@ -189,12 +189,12 @@ export default function Plausible(
     ...defaults,
   });
 
-  const trackEvent: TrackEvent = (eventName, eventData, options) => {
+  const trackEvent: TrackEvent = (eventName, options, eventData) => {
     sendEvent(eventName, { ...getConfig(), ...eventData }, options);
   };
 
   const trackPageview: TrackPageview = (eventData, options) => {
-    trackEvent('pageview', eventData, options);
+    trackEvent('pageview', options, eventData);
   };
 
   const enableAutoPageviews: EnableAutoPageviews = () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds support for [custom props for goals](https://docs.plausible.io/custom-event-goals#using-custom-props).

This PR also changes the argument order of `trackEvent`, so it is easier to bind props to goals.

Binding props can be done by passing a `props` object inside the second parameter of `trackEvent` or the second parameter of `trackPageview`:
```ts
trackEvent('Download', { props: { method: 'HTTP' } })
```

### **BREAKING CHANGES**
The order of `trackEvent`'s arguments has been changed.
- Before:
```ts
trackEvent('myGoal', { trackLocalhost: true }, { callback: () => console.log('done') })
```
- After:
```ts
trackEvent('myGoal', { callback: () => console.log('done') }, { trackLocalhost: true })
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fixes #2 

## Screenshots or GIFs (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/Maronato/plausible-tracker/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
