### PR TITLE
feat(tracker): add automatic outbound link tracking

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -28,7 +28,8 @@
     "GIFs",
     "popstate",
     "hashchange",
-    "signup"
+    "signup",
+    "automagically"
   ],
   "flagWords": [],
   "ignorePaths": [

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Frontend library to interact with [Plausible Analytics](https://plausible.io/).
     - [Automatically tracking page views](#automatically-tracking-page-views)
       - [Cleaning up the event listeners](#cleaning-up-the-event-listeners)
     - [Tracking custom events and goals](#tracking-custom-events-and-goals)
+    - [Outbound link click tracking](#outbound-link-click-tracking)
+      - [Cleaning up the event listeners](#cleaning-up-the-event-listeners-1)
   - [Reference documentation](#reference-documentation)
 
 ## Features
@@ -201,6 +203,40 @@ trackEvent(
   },
   { trackLocalhost: true }
 );
+```
+
+### Outbound link click tracking
+
+You can also track all clicks to outbound links using `enableAutoOutboundTracking`.
+
+For details on how to setup the tracking, visit the [docs](https://docs.plausible.io/outbound-link-click-tracking).
+
+This function adds a `click` event listener to all `a` tags on the page and reports them to Plausible. It also creates a [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) that efficiently tracks node mutations, so dynamically-added links are also tracked.
+
+```ts
+import Plausible from 'plausible-tracker'
+
+const { enableAutoOutboundTracking } = Plausible()
+
+// Track all existing and future outbound links
+enableAutoOutboundTracking()
+```
+
+#### Cleaning up the event listeners
+
+When you call `enableAutoOutboundTracking()`, it adds some event listeners and initializes a `MutationObserver`. To remove them, call the cleanup function returned by `enableAutoOutboundTracking()`:
+
+```ts
+import Plausible from 'plausible-tracker'
+
+const { enableAutoOutboundTracking } = Plausible()
+
+const cleanup = enableAutoOutboundTracking()
+
+// ...
+
+// Remove event listeners and disconnect the MutationObserver
+cleanup()
 ```
 
 ## Reference documentation


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds automatic outbound link tracking through a new function: `enableAutoOutboundTracking`
 
It works using a **[MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver)** to automagically detect link nodes throughout your application and bind `click` events to them.
 
Optionally takes the same parameters as [`MutationObserver.observe`](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/observe).
 
### Example
```js
import Plausible from 'plausible-tracker'
 
const { enableAutoOutboundTracking } = Plausible()
 
// This tracks all the existing and future outbound links on your page.
enableAutoOutboundTracking()
```
 
The returned value is a callback that removes the added event listeners and disconnects the observer
```js
import Plausible from 'plausible-tracker'
 
const { enableAutoOutboundTracking } = Plausible()
 
const cleanup = enableAutoOutboundTracking()
 
// Remove event listeners and disconnect the observer
cleanup()
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Screenshots or GIFs (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/Maronato/plausible-tracker/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
