### PR TITLE
feat: add an enabled flag to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ const plausible = Plausible({
 
 | Option         | Type     | Description                                                       | Default                  |
 | -------------- | -------- | ----------------------------------------------------------------- | ------------------------ |
+| enabled        | `bool`   | Enables sending event data to Plausible.                          | `true`                   |
 | domain         | `string` | Your site's domain, as declared by you in Plausible's settings    | `location.hostname`      |
 | hashMode       | `bool`   | Enables tracking based on URL hash changes.                       | `false`                  |
 | trackLocalhost | `bool`   | Enables tracking on *localhost*.                                  | `false`                  |
@@ -108,7 +109,7 @@ trackPageview({
 })
 ```
 
-The second parameter is an object with [some options](https://plausible-tracker.netlify.app/globals.html#eventoptions) similar to the ones provided by the [official Plausible script](https://docs.plausible.io/custom-event-goals). 
+The second parameter is an object with [some options](https://plausible-tracker.netlify.app/globals.html#eventoptions) similar to the ones provided by the [official Plausible script](https://docs.plausible.io/custom-event-goals).
 
 ```ts
 import Plausible from 'plausible-tracker'

--- a/src/lib/request.spec.ts
+++ b/src/lib/request.spec.ts
@@ -20,6 +20,7 @@ let xhrMockClass: ReturnType<typeof getXhrMockClass>;
 const xmr = jest.spyOn(window, 'XMLHttpRequest');
 
 const defaultData: Required<PlausibleOptions> = {
+  enabled: true,
   hashMode: false,
   trackLocalhost: false,
   url: 'https://my-app.com/my-url',
@@ -92,6 +93,11 @@ describe('sendEvent', () => {
     };
 
     expect(xhrMockClass.send).toHaveBeenCalledWith(JSON.stringify(payload));
+  });
+  test('does not send when disabled', () => {
+    expect(xmr).not.toHaveBeenCalled();
+    sendEvent('myEvent', { ...defaultData, enabled: false });
+    expect(xmr).not.toHaveBeenCalled();
   });
   test('does not send to localhost', () => {
     window.location.hostname = 'localhost';

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -37,6 +37,12 @@ export function sendEvent(
   data: Required<PlausibleOptions>,
   options?: EventOptions
 ): void {
+  if (!data.enabled) {
+    return console.warn(
+      '[Plausible] Ignoring event because Plausible is not enabled'
+    );
+  }
+
   const isLocalhost =
     /^localhost$|^127(?:\.[0-9]+){0,2}\.[0-9]+$|^(?:0*:)*?:?0*1$/.test(
       location.hostname

--- a/src/lib/tracker.spec.ts
+++ b/src/lib/tracker.spec.ts
@@ -11,6 +11,7 @@ beforeEach(() => {
 
 describe('tracker', () => {
   const getDefaultData: () => Required<PlausibleOptions> = () => ({
+    enabled: true,
     hashMode: false,
     trackLocalhost: false,
     url: location.href,
@@ -21,6 +22,7 @@ describe('tracker', () => {
   });
 
   const getCustomData: () => Required<PlausibleOptions> = () => ({
+    enabled: true,
     hashMode: true,
     trackLocalhost: true,
     url: 'https://my-url.com',

--- a/src/lib/tracker.ts
+++ b/src/lib/tracker.ts
@@ -5,6 +5,11 @@ import { EventOptions, sendEvent } from './request';
  */
 export type PlausibleInitOptions = {
   /**
+   * If false, events will not be sent to Plausible.
+   * Defaults to `true`.
+   */
+  readonly enabled?: boolean;
+  /**
    * If true, pageviews will be tracked when the URL hash changes.
    * Enable this if you are using a frontend that uses hash-based routing.
    */
@@ -216,6 +221,7 @@ export default function Plausible(
   readonly enableAutoOutboundTracking: EnableAutoOutboundTracking;
 } {
   const getConfig = (): Required<PlausibleOptions> => ({
+    enabled: true,
     hashMode: false,
     trackLocalhost: false,
     url: location.href,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds an `enabled` `bool` option that would disable sending any events to Plausible, but keep all functions working.

## Related Issue
Fixes https://github.com/plausible/plausible-tracker/issues/9

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/Maronato/plausible-tracker/blob/master/CONTRIBUTING.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
