### PR TITLE
Adds additional check if process is undefined

### DIFF
--- a/src/lib/tracker.ts
+++ b/src/lib/tracker.ts
@@ -282,7 +282,7 @@ export default function Plausible(
       /* istanbul ignore next */
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      if (!(process && process.env.NODE_ENV === 'test')) {
+      if (!(typeof(process) !== 'undefined' && process && process.env.NODE_ENV === 'test')) {
         setTimeout(() => {
           // eslint-disable-next-line functional/immutable-data
           location.href = this.href;


### PR DESCRIPTION
In my project there was an issue where `process` was undefined. Not quite sure, how and why. This happens only when a link is clicked in a modal. 🤷 

 This adds a safe way of checking if the variable is set without crashing.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING**](https://github.com/Maronato/plausible-tracker/blob/master/CONTRIBUTING.md) document.
