### PR TITLE
Respect `localStorage.plausible_ignore`

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,5 +239,11 @@ const cleanup = enableAutoOutboundTracking()
 cleanup()
 ```
 
+### Opt out and exclude yourself from the analytics
+
+Since plausible-tracker is bundled with your application code, using an ad-blocker to exclude your visits isn't an option. Fortunately Plausible has an alternative for this scenario: plausible-tracker will not send events if `localStorage.plausible_ignore` is set to `"true"`.
+
+More information about this method can be found in the [Plausible documentation](https://plausible.io/docs/excluding-localstorage).
+
 ## Reference documentation
 For the full method and type documentation, check out the [reference documentation](https://plausible-tracker.netlify.app).

--- a/src/lib/request.spec.ts
+++ b/src/lib/request.spec.ts
@@ -111,6 +111,18 @@ describe('sendEvent', () => {
     sendEvent('myEvent', { ...defaultData, trackLocalhost: true });
     expect(xmr).toHaveBeenCalled();
   });
+  test('does not send if "plausible_ignore" is set to "true" in localStorage', () => {
+    window.localStorage.setItem('plausible_ignore', 'true');
+    expect(xmr).not.toHaveBeenCalled();
+    sendEvent('myEvent', defaultData);
+    expect(xmr).not.toHaveBeenCalled();
+
+    window.localStorage.setItem('plausible_ignore', 'something-not-true');
+    sendEvent('myEvent', defaultData);
+    expect(xmr).toHaveBeenCalled();
+
+    window.localStorage.removeItem('plausible_ignore');
+  });
   test('calls callback', () => {
     expect(xmr).not.toHaveBeenCalled();
     const callback = jest.fn();

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -48,6 +48,14 @@ export function sendEvent(
     );
   }
 
+  const shouldIgnoreCurrentBrowser =
+    localStorage.getItem('plausible_ignore') === 'true';
+  if (shouldIgnoreCurrentBrowser) {
+    return console.warn(
+      '[Plausible] Ignoring event because "plausible_ignore" is set to "true" in localStorage'
+    );
+  }
+
   const payload: EventPayload = {
     n: eventName,
     u: data.url,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change ensures no events are sent if `localStorage.plausible_ignore` is set to `"true"`. This behaviour is consistent with the standalone script.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#8 
## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/Maronato/plausible-tracker/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
