### PR TITLE
Include src/ directory in npm package to fix source map loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "files": [
     "build/main",
     "build/module",
+    "src",
     "!**/*.spec.*",
     "!**/*.json",
     "CHANGELOG.md",


### PR DESCRIPTION
## Description
The compiled JavaScript we ship includes embedded source maps because we enable `"inlineSourceMap"` in `tsconfig.json`. Those source maps reference the original TypeScript files by name instead of embedding their contents because we don't set `"inlineSources"`.

However, we currently don't include those TypeScript files in the package we distribute. We only include the compiled files from `build/`. This causes a warning when source-map-loader, run from a downstream package, tries to load maps:

    WARNING in ./node_modules/plausible-tracker/build/module/index.js
    Module Warning (from ./node_modules/source-map-loader/dist/cjs.js):
    Failed to parse source map from '.../node_modules/plausible-tracker/src/index.ts' file: Error: ENOENT: no such file or directory, open '.../node_modules/plausible-tracker/src/index.ts'
     @ ./src/analytics/plausible.ts 3:0-42 11:29-38
     @ ./src/index.tsx 8:0-55 13:0-14

To fix the issue, add `src/` to `"files"` in `package.json`. Alternatively, we could have set `"inlineSources"` to `true` in `tsconfig.json`, but that results in the TypeScript being encoded as Base64, which is less efficient than just shipping the files directly.

## Related Issue
#22

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/Maronato/plausible-tracker/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
