### PR TITLE
Check for localStorage support

### DIFF
--- a/src/lib/request.spec.ts
+++ b/src/lib/request.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable functional/no-let */
 /* eslint-disable functional/immutable-data */
-import { sendEvent } from './request';
+import { checkLocalStorageSupport, sendEvent } from './request';
 import { PlausibleOptions } from './tracker';
 
 const getXhrMockClass = () => ({
@@ -110,6 +110,15 @@ describe('sendEvent', () => {
     expect(xmr).not.toHaveBeenCalled();
     sendEvent('myEvent', { ...defaultData, trackLocalhost: true });
     expect(xmr).toHaveBeenCalled();
+  });
+  test('can determine if localStorage is supported in an inlined data:uri iframe', () => {
+    const fauxWindow = {} as Window;
+    const hasLocalStorageSupport = checkLocalStorageSupport(fauxWindow);
+    expect(hasLocalStorageSupport).toBeFalsy();
+  });
+  test('can determine if localStorage is supported in a true DOM environment with a window object', () => {
+    const hasLocalStorageSupport = checkLocalStorageSupport();
+    expect(hasLocalStorageSupport).toBeTruthy();
   });
   test('does not send if "plausible_ignore" is set to "true" in localStorage', () => {
     window.localStorage.setItem('plausible_ignore', 'true');

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -25,6 +25,19 @@ export type EventOptions = {
   readonly props?: { readonly [propName: string]: string };
 };
 
+
+export const checkLocalStorageSupport = (g?: Window | typeof globalThis | Window & typeof globalThis): boolean => {
+  try {
+    if ( g ) {
+      return "localStorage" in g && g["localStorage"] !== null;
+    } else {
+      return "localStorage" in window && window["localStorage"] !== null;
+    }
+  } catch (_e) {
+    return false;
+  }
+};
+
 /**
  * @internal
  * Sends an event to Plausible's API
@@ -48,8 +61,10 @@ export function sendEvent(
     );
   }
 
-  const shouldIgnoreCurrentBrowser =
-    localStorage.getItem('plausible_ignore') === 'true';
+  
+  const hasLocalStorageSupport = checkLocalStorageSupport();
+  const shouldIgnoreCurrentBrowser = hasLocalStorageSupport && localStorage.getItem('plausible_ignore') === 'true';
+
   if (shouldIgnoreCurrentBrowser) {
     return console.warn(
       '[Plausible] Ignoring event because "plausible_ignore" is set to "true" in localStorage'


### PR DESCRIPTION
Adds a function called `checkLocalStorageSupport` before invoking `localStorage.getItem`


## Description

In some environments, for example: Figma plugins that are entirely inlined data:uri blobs, `localStorage` is not useable on the parent frame/window object. This first checks support, and allows plausible tracker to be used in some non-traditional contexts.

Should not introduce any breaking changes. Two unit tests are added as well. 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/Maronato/plausible-tracker/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
