### PR TITLE
fix(request): accept number and boolean as event props

### DIFF
--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -22,7 +22,7 @@ export type EventOptions = {
   /**
    * Properties to be bound to the event.
    */
-  readonly props?: { readonly [propName: string]: string };
+  readonly props?: { readonly [propName: string]: string | number | boolean };
 };
 
 /**

--- a/src/lib/tracker.spec.ts
+++ b/src/lib/tracker.spec.ts
@@ -35,6 +35,8 @@ describe('tracker', () => {
     props: {
       variation1: 'A',
       variation2: 'B',
+      variation3: 1,
+      variation4: true,
     },
   });
 


### PR DESCRIPTION
## Description

According to Plausible docs, event props can be strings, numbers or booleans: https://plausible.io/docs/custom-event-goals#using-custom-props

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/Maronato/plausible-tracker/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
