### PR TITLE
Fix page reloads on missing hrefs

### DIFF
--- a/src/lib/tracker.ts
+++ b/src/lib/tracker.ts
@@ -277,6 +277,10 @@ export default function Plausible(
     }
   ) => {
     function trackClick(this: HTMLAnchorElement, event: MouseEvent) {
+      if (!this.href) {
+        return;
+      }
+
       trackEvent('Outbound Link: Click', { props: { url: this.href } });
 
       /* istanbul ignore next */


### PR DESCRIPTION
Added a check for the `href` attribute to the anchor link click event listener.

## Description
Since the package updates the event listener of all anchor links on the website, sometimes we might not want the behavior of the new event listener to run. In this specific example, if an anchor tag doesn't have a `href` attribute, the page would just reload. Sometimes the lack of href tags is intentional. For example, the hamburger menu in Buefy's navigation component looks like this:

```html
<a role="button" aria-label="menu" class="navbar-burger burger"> ... </a>
```

In this scenario, the hamburger anchor opens the menu but then the page reloads. My change makes sure the `href` attribute actually exists before doing anything.

## Related Issue
N/A

## Screenshots or GIFs (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/Maronato/plausible-tracker/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
