### PR TITLE
Don't access localStorage if it is not available

### DIFF
--- a/src/lib/request.spec.ts
+++ b/src/lib/request.spec.ts
@@ -123,6 +123,20 @@ describe('sendEvent', () => {
 
     window.localStorage.removeItem('plausible_ignore');
   });
+  test('does not throw an error if localStorage is not available', () => {
+    const localStorage = window.localStorage;
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    delete window['localStorage'];
+
+    expect(xmr).not.toHaveBeenCalled();
+    sendEvent('myEvent', defaultData);
+    expect(xmr).toHaveBeenCalled();
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    window.localStorage = localStorage;
+  });
   test('calls callback', () => {
     expect(xmr).not.toHaveBeenCalled();
     const callback = jest.fn();

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -48,8 +48,13 @@ export function sendEvent(
     );
   }
 
+  const canAccessLocalStorage =
+    typeof window.localStorage?.getItem === 'function';
+
   const shouldIgnoreCurrentBrowser =
+    canAccessLocalStorage &&
     localStorage.getItem('plausible_ignore') === 'true';
+
   if (shouldIgnoreCurrentBrowser) {
     return console.warn(
       '[Plausible] Ignoring event because "plausible_ignore" is set to "true" in localStorage'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The changes introduced by https://github.com/plausible/plausible-tracker/pull/17 throw exceptions when localStorage is not available. Some browsers completely remove the localStorage key when certain settings are enabled (for example: "disable all cookies"). This adds an extra check to ensure localStorage is available before accessing it.


## Related Issue
Fixes https://github.com/plausible/plausible-tracker/issues/25
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/Maronato/plausible-tracker/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
