### PR TITLE
Honor target attribute for outbound link tracking by relying on `navigator.sendBeacon`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ const plausible = Plausible({
 | hashMode       | `bool`   | Enables tracking based on URL hash changes.                       | `false`                  |
 | trackLocalhost | `bool`   | Enables tracking on *localhost*.                                  | `false`                  |
 | apiHost        | `string` | Plausible's API host to use. Change this if you are self-hosting. | `'https://plausible.io'` |
+| useSendBeacon  | `bool`   | Enables the use of `navigator.sendBeacon` method to send events.  | `false`                  |
 
 The object returned from `Plausible()` contains the functions that you'll use to track your events. These functions are:
 
@@ -211,7 +212,7 @@ You can also track all clicks to outbound links using `enableAutoOutboundTrackin
 
 For details on how to setup the tracking, visit the [docs](https://docs.plausible.io/outbound-link-click-tracking).
 
-This function adds a `click` event listener to all `a` tags on the page and reports them to Plausible. It also creates a [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) that efficiently tracks node mutations, so dynamically-added links are also tracked.
+This function adds a `click` event listener to all `a` tags on the page and reports them to Plausible. It also creates a [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) that efficiently tracks node mutations, so dynamically-added links are also tracked. Event is sent with `navigator.sendBeacon` method.
 
 ```ts
 import Plausible from 'plausible-tracker'

--- a/src/lib/request.spec.ts
+++ b/src/lib/request.spec.ts
@@ -29,6 +29,7 @@ const sendBeacon = jest.spyOn(navigator, 'sendBeacon');
 const defaultData: Required<PlausibleOptions> = {
   hashMode: false,
   trackLocalhost: false,
+  useSendBeacon: false,
   url: 'https://my-app.com/my-url',
   domain: 'my-app.com',
   referrer: null,
@@ -87,7 +88,7 @@ describe('sendEvent', () => {
   });
   test('sends via Navigator#sendBeacon', () => {
     expect(sendBeacon).not.toHaveBeenCalled();
-    sendEvent('myEvent', defaultData, { useSendBeacon: true });
+    sendEvent('myEvent', { ...defaultData, useSendBeacon: true });
     expect(sendBeacon).toHaveBeenCalledTimes(1);
 
     const payload = {

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -23,10 +23,6 @@ export type EventOptions = {
    * Properties to be bound to the event.
    */
   readonly props?: { readonly [propName: string]: string | number | boolean };
-  /**
-   * Whether to use `Navigator#sendBeacon`.
-   */
-  readonly useSendBeacon?: boolean;
 };
 
 /**
@@ -72,7 +68,7 @@ export function sendEvent(
     p: options && options.props ? JSON.stringify(options.props) : undefined,
   };
 
-  if (!options?.useSendBeacon) {
+  if (!data?.useSendBeacon) {
     const req = new XMLHttpRequest();
     req.open('POST', `${data.apiHost}/api/event`, true);
     req.setRequestHeader('Content-Type', 'text/plain');

--- a/src/lib/tracker.spec.ts
+++ b/src/lib/tracker.spec.ts
@@ -38,6 +38,7 @@ describe('tracker', () => {
       variation3: 1,
       variation4: true,
     },
+    useSendBeacon: false,
   });
 
   test('inits with default config', () => {

--- a/src/lib/tracker.spec.ts
+++ b/src/lib/tracker.spec.ts
@@ -13,6 +13,7 @@ describe('tracker', () => {
   const getDefaultData: () => Required<PlausibleOptions> = () => ({
     hashMode: false,
     trackLocalhost: false,
+    useSendBeacon: false,
     url: location.href,
     domain: location.hostname,
     referrer: document.referrer || null,
@@ -23,6 +24,7 @@ describe('tracker', () => {
   const getCustomData: () => Required<PlausibleOptions> = () => ({
     hashMode: true,
     trackLocalhost: true,
+    useSendBeacon: false,
     url: 'https://my-url.com',
     domain: 'my-domain.com',
     referrer: 'my-referrer',
@@ -38,7 +40,6 @@ describe('tracker', () => {
       variation3: 1,
       variation4: true,
     },
-    useSendBeacon: false,
   });
 
   test('inits with default config', () => {

--- a/src/lib/tracker.ts
+++ b/src/lib/tracker.ts
@@ -23,6 +23,11 @@ export type PlausibleInitOptions = {
    * Defaults to `'https://plausible.io'`
    */
   readonly apiHost?: string;
+  /**
+   * Whether to use `Navigator#sendBeacon`.
+   * Defaults to `false`.
+   */
+  readonly useSendBeacon?: boolean;
 };
 
 /**
@@ -223,6 +228,7 @@ export default function Plausible(
     referrer: document.referrer || null,
     deviceWidth: window.innerWidth,
     apiHost: 'https://plausible.io',
+    useSendBeacon: false,
     ...defaults,
   });
 
@@ -276,26 +282,8 @@ export default function Plausible(
       attributeFilter: ['href'],
     }
   ) => {
-    function trackClick(this: HTMLAnchorElement, event: MouseEvent) {
-      trackEvent('Outbound Link: Click', { props: { url: this.href } });
-
-      /* istanbul ignore next */
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      if (
-        !(
-          typeof process !== 'undefined' &&
-          process &&
-          process.env.NODE_ENV === 'test'
-        )
-      ) {
-        setTimeout(() => {
-          // eslint-disable-next-line functional/immutable-data
-          location.href = this.href;
-        }, 150);
-      }
-
-      event.preventDefault();
+    function trackClick(this: HTMLAnchorElement, _: MouseEvent) {
+      trackEvent('Outbound Link: Click', { props: { url: this.href } }, { useSendBeacon: true });
     }
 
     // eslint-disable-next-line functional/prefer-readonly-type


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Continue the effort from the PR https://github.com/plausible/plausible-tracker/pull/45.
The outbound link tracking event is sent with `navigator.sendBeacon` to honor the target attribute for outbound link tracking.

uBlock Origin prevents ping requests with `navigator.sendBeacon` when the "Disable hyperlink auditing" option is enabled https://github.com/gorhill/uBlock/wiki/Dashboard:-Settings#disable-hyperlink-auditing


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes https://github.com/plausible/plausible-tracker/issues/12 
Implement https://github.com/plausible/plausible-tracker/issues/16

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/Maronato/plausible-tracker/blob/master/CONTRIBUTING.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
